### PR TITLE
Fix compatibility with newer kustomize.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ deploy: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
-	kustomize build config/default/ > provider-components.yaml
+	kustomize build config/ > provider-components.yaml
 	echo "---" >> provider-components.yaml
 	cd vendor && kustomize build sigs.k8s.io/cluster-api/config/default/ >> ../provider-components.yaml
 

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -18,22 +18,22 @@ namePrefix: cluster-api-provider-baremetal-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
+- rbac/rbac_role.yaml
+- rbac/rbac_role_binding.yaml
+- manager/manager.yaml
   # Comment the following 3 lines if you want to disable
   # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
   # which protects your /metrics endpoint.
-- ../rbac/auth_proxy_service.yaml
-- ../rbac/auth_proxy_role.yaml
-- ../rbac/auth_proxy_role_binding.yaml
+- rbac/auth_proxy_service.yaml
+- rbac/auth_proxy_role.yaml
+- rbac/auth_proxy_role_binding.yaml
 
 patches:
-- manager_image_patch.yaml
+- default/manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-- manager_auth_proxy_patch.yaml
+- default/manager_auth_proxy_patch.yaml
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, uncomment the following line and
   # comment manager_auth_proxy_patch.yaml.


### PR DESCRIPTION
The newest releases of kustomize block relative paths in the config.  This patch pulls in a fix to our vendored copy of cluster-api, and fixes our own config as well.