### PR TITLE
Add metrics-addr flag.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,13 +38,15 @@ func main() {
 		panic(fmt.Errorf("GetConfigOrDie didn't die"))
 	}
 
+	metricsAddr := flag.String("metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.Parse()
+
 	log := logf.Log.WithName("baremetal-controller-manager")
 	logf.SetLogger(logf.ZapLogger(false))
 	entryLog := log.WithName("entrypoint")
 
 	// Setup a Manager
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: *metricsAddr})
 	if err != nil {
 		entryLog.Error(err, "unable to set up overall controller manager")
 		os.Exit(1)


### PR DESCRIPTION
This patch syncs a change from the upstream cluster-api provider
implementation documentation.  See this PR for the change:

https://github.com/kubernetes-sigs/cluster-api/pull/780

and this issue for some more information about the problem it's
fixing:

https://github.com/kubernetes-sigs/cluster-api/issues/742

Signed-off-by: Russell Bryant <rbryant@redhat.com>