### PR TITLE
Fix RBAC generation from the code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ deploy: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd
+	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	kustomize build config/default/ > provider-components.yaml
 	echo "---" >> provider-components.yaml
 	cd vendor && kustomize build github.com/openshift/cluster-api/config/default/ >> ../provider-components.yaml

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -5,6 +5,59 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - cluster.k8s.io
+  resources:
+  - machines
+  - machines/status
+  - machinedeployments
+  - machinedeployments/status
+  - machinesets
+  - machinesets/status
+  - machineclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - cluster.k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - baremetal.k8s.io
+  resources:
+  - baremetalmachineproviderspecs
+  - baremetalmachineproviderstatuses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations


### PR DESCRIPTION
A previous commit from PR #6 added directives in the code for setting
ClusterRole permissions.  This commit adds the corresponding necessary
change to the Makefile to act on those directives.

This corresponds to the following PR from cluster-api's provider
implementation documentation:

https://github.com/kubernetes-sigs/cluster-api/pull/779

Signed-off-by: Russell Bryant <rbryant@redhat.com>