### PR TITLE
uses k8s.io/client-go/tools/cache to generate host annotation value

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -992,6 +992,7 @@
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
+    "k8s.io/client-go/tools/cache",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "sigs.k8s.io/controller-runtime/pkg/client",

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -152,7 +152,7 @@ func TestExists(t *testing.T) {
 			Machine: machinev1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						HostAnnotation: "somehost",
+						HostAnnotation: "myns/somehost",
 					},
 				},
 			},
@@ -164,7 +164,7 @@ func TestExists(t *testing.T) {
 			Machine: machinev1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						HostAnnotation: "myns",
+						HostAnnotation: "myns/wrong",
 					},
 				},
 			},
@@ -219,7 +219,7 @@ func TestGetHost(t *testing.T) {
 			Machine: machinev1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						HostAnnotation: "myhost",
+						HostAnnotation: "myns/myhost",
 					},
 				},
 			},
@@ -231,7 +231,7 @@ func TestGetHost(t *testing.T) {
 			Machine: machinev1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						HostAnnotation: "myns",
+						HostAnnotation: "myns/wrong",
 					},
 				},
 			},
@@ -277,7 +277,7 @@ func TestEnsureAnnotation(t *testing.T) {
 			Machine: machinev1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						HostAnnotation: "myhost",
+						HostAnnotation: "myns/myhost",
 					},
 				},
 			},
@@ -293,7 +293,7 @@ func TestEnsureAnnotation(t *testing.T) {
 			Machine: machinev1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						HostAnnotation: "wrongvalue",
+						HostAnnotation: "myns/wrongvalue",
 					},
 				},
 			},
@@ -359,8 +359,8 @@ func TestEnsureAnnotation(t *testing.T) {
 		if !ok {
 			t.Error("host annotation not found")
 		}
-		if result != tc.Host.Name {
-			t.Errorf("host annotation has value %s, expected %s", result, tc.Host.Name)
+		if result != "myns/myhost" {
+			t.Errorf("host annotation has value %s, expected \"myns/myhost\"", result)
 		}
 	}
 }
@@ -393,7 +393,7 @@ func TestDelete(t *testing.T) {
 					Name:      "mymachine",
 					Namespace: "myns",
 					Annotations: map[string]string{
-						HostAnnotation: "myhost",
+						HostAnnotation: "myns/myhost",
 					},
 				},
 			},
@@ -417,7 +417,7 @@ func TestDelete(t *testing.T) {
 					Name:      "mymachine",
 					Namespace: "myns",
 					Annotations: map[string]string{
-						HostAnnotation: "myhost",
+						HostAnnotation: "myns/myhost",
 					},
 				},
 			},
@@ -439,7 +439,7 @@ func TestDelete(t *testing.T) {
 					Name:      "mymachine",
 					Namespace: "myns",
 					Annotations: map[string]string{
-						HostAnnotation: "myhost",
+						HostAnnotation: "myns/myhost",
 					},
 				},
 			},
@@ -452,7 +452,7 @@ func TestDelete(t *testing.T) {
 					Name:      "mymachine",
 					Namespace: "myns",
 					Annotations: map[string]string{
-						HostAnnotation: "myhost",
+						HostAnnotation: "myns/myhost",
 					},
 				},
 			},


### PR DESCRIPTION
I noticed that ReconcileMachineHealthCheck in the machine-api-operator uses
this approach when it puts a machine annotation on a Node. It seems worth using
the same approach for the host annotation.