### PR TITLE
gracefully requeues when no host is available

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -109,11 +109,8 @@ func TestChooseHost(t *testing.T) {
 
 		result, err := actuator.chooseHost(context.TODO(), &tc.Machine)
 		if tc.ExpectedHostName == "" {
-			if err == nil {
-				t.Error("found host when none should have been available")
-			}
 			if result != nil {
-				t.Errorf("expected nil, got %v", result)
+				t.Error("found host when none should have been available")
 			}
 			continue
 		}


### PR DESCRIPTION
Previously if no host was available, the actuator would return an error. This
caused the controller to log an ugly stacktrace and retry every second, with a
gradual backoff to once every ~30 seconds.

With this change, there is no more stacktrace logged, and the retry interval is
fixed at 30s.

New log output:

```
2019/03/25 09:01:39 Checking if machine sample exists.
2019/03/25 09:01:39 Machine sample does not exist.
2019/03/25 09:01:39 Creating machine sample .
2019/03/25 09:01:39 No available host found. Requeuing.
```

Old log output:

```
2019/03/25 09:02:19 Checking if machine sample exists.
2019/03/25 09:02:19 Machine sample does not exist.
2019/03/25 09:02:19 Creating machine sample .
{"level":"error","ts":1553518939.1828089,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"machine-controller","request":"default/sample","error":"No available host found","stacktrace":"github.com/metalkube/cluster-api-provider-baremetal/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/mhrivnak/golang/src/github.com/metalkube/cluster-api-provider-baremetal/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/metalkube/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/mhrivnak/golang/src/github.com/metalkube/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\ngithub.com/metalkube/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/home/mhrivnak/golang/src/github.com/metalkube/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/metalkube/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/home/mhrivnak/golang/src/github.com/metalkube/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/metalkube/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/mhrivnak/golang/src/github.com/metalkube/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/metalkube/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/home/mhrivnak/golang/src/github.com/metalkube/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```