### PR TITLE
cmd/manager: remove duplicate klog calls

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -43,18 +43,6 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 	entryLog := log.WithName("entrypoint")
 
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-
-	// Sync the glog and klog flags.
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			f2.Value.Set(value)
-		}
-	})
-
 	cfg := config.GetConfigOrDie()
 	if cfg == nil {
 		panic(fmt.Errorf("GetConfigOrDie didn't die"))


### PR DESCRIPTION
Duplicate InitFlags and glog sync are not required

See https://github.com/kubernetes-sigs/cluster-api/pull/850#discussion_r268641086