### PR TITLE
set the host online when we provision it

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -245,6 +245,7 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine) (
 		URL:      instanceImageSource,
 		Checksum: instanceImageChecksumURL,
 	}
+	chosenHost.Spec.Online = true
 	err := a.client.Update(ctx, chosenHost)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There's no point in provisioning to a host that is powered off.