### PR TITLE
fixes bug that chose the same host every time

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -223,17 +223,19 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine) (
 
 	availableHosts := []*bmh.BareMetalHost{}
 
-	for _, host := range hosts.Items {
+	for i, host := range hosts.Items {
 		if host.Available() {
-			availableHosts = append(availableHosts, &host)
+			availableHosts = append(availableHosts, &hosts.Items[i])
 		} else if host.Spec.MachineRef.Name == machine.Name && host.Spec.MachineRef.Namespace == machine.Namespace {
 			log.Printf("found host %s with existing MachineRef", host.Name)
-			return &host, nil
+			return &hosts.Items[i], nil
 		}
 	}
 	if len(availableHosts) == 0 {
 		return nil, nil
 	}
+
+	log.Printf("%d hosts available", len(availableHosts))
 	// choose a host at random from available hosts
 	rand.Seed(time.Now().Unix())
 	chosenHost := availableHosts[rand.Intn(len(availableHosts))]

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -69,7 +69,7 @@ func TestChooseHost(t *testing.T) {
 					Namespace: "myns",
 				},
 			},
-			Hosts:            []runtime.Object{&host1, &host2},
+			Hosts:            []runtime.Object{&host2, &host1},
 			ExpectedHostName: host2.Name,
 		},
 		{
@@ -80,7 +80,7 @@ func TestChooseHost(t *testing.T) {
 					Namespace: "myns",
 				},
 			},
-			Hosts:            []runtime.Object{&host1, &host2, &host3},
+			Hosts:            []runtime.Object{&host1, &host3, &host2},
 			ExpectedHostName: host3.Name,
 		},
 		{


### PR DESCRIPTION
A pointer bug caused the actuator to always choose the last host in the slice
of hosts, regardless of whether it was available or not.

The unit tests could have caught this bug, except that the test data happened
to be arranged such that the expected correct host to choose was always the
last one in the slice.

fixes #51