### PR TITLE
Waits for metalkube.org API group to be available before starting.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,10 +20,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	bmoapis "github.com/metalkube/baremetal-operator/pkg/apis"
 	"github.com/metalkube/cluster-api-provider-baremetal/pkg/apis"
 	"github.com/metalkube/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	clusterapis "sigs.k8s.io/cluster-api/pkg/apis"
 	capimachine "sigs.k8s.io/cluster-api/pkg/controller/machine"
@@ -46,6 +50,12 @@ func main() {
 	cfg := config.GetConfigOrDie()
 	if cfg == nil {
 		panic(fmt.Errorf("GetConfigOrDie didn't die"))
+	}
+
+	err := waitForAPIs(cfg)
+	if err != nil {
+		entryLog.Error(err, "unable to discover required APIs")
+		os.Exit(1)
 	}
 
 	// Setup a Manager
@@ -80,4 +90,31 @@ func main() {
 		entryLog.Error(err, "unable to run manager")
 		os.Exit(1)
 	}
+}
+
+func waitForAPIs(cfg *rest.Config) error {
+	log := logf.Log.WithName("baremetal-controller-manager")
+
+	c, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	metalkubeGV := schema.GroupVersion{
+		Group:   "metalkube.org",
+		Version: "v1alpha1",
+	}
+
+	for {
+		err = discovery.ServerSupportsVersion(c, metalkubeGV)
+		if err != nil {
+			log.Info(fmt.Sprintf("Waiting for API group %v to be available: %v", metalkubeGV, err))
+			time.Sleep(time.Second * 10)
+			continue
+		}
+		log.Info(fmt.Sprintf("Found API group %v", metalkubeGV))
+		break
+	}
+
+	return nil
 }

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -199,6 +199,7 @@ func (a *Actuator) getHost(ctx context.Context, machine *machinev1.Machine) (*bm
 	}
 	err = a.client.Get(ctx, key, &host)
 	if errors.IsNotFound(err) {
+		log.Printf("Annotated host %s not found", hostKey)
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -219,7 +220,10 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine) (
 	opts := &client.ListOptions{
 		Namespace: machine.Namespace,
 	}
-	a.client.List(ctx, opts, &hosts)
+	err := a.client.List(ctx, opts, &hosts)
+	if err != nil {
+		return nil, err
+	}
 
 	availableHosts := []*bmh.BareMetalHost{}
 
@@ -256,7 +260,7 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine) (
 		// FIXME(dhellmann): Is this name openshift-specific?
 		Name: "worker-user-data",
 	}
-	err := a.client.Update(ctx, chosenHost)
+	err = a.client.Update(ctx, chosenHost)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes a bug where the client caches the non-existence of a CRD, so if the
metalkube.org group doesn't exist when the controller starts, it will never
succeed at Listing or Getting BareMetalHosts.

Includes minor improvements to logging and error checking.

fixes #57