### PR TITLE
Fix error while adding CRDs from cluster-api

### DIFF
--- a/docs/dev/minikube.md
+++ b/docs/dev/minikube.md
@@ -9,7 +9,7 @@ Once your cluster is running, the CRDs defined by the `cluster-api` project
 need to be added to the cluster.
 
 ```bash
-kubectl apply -f vendor/sigs.k8s.io/cluster-api/config/crds/
+kubectl apply -k vendor/sigs.k8s.io/cluster-api/config/crds/
 ```
 
 ## Add CRDs from baremetal-operator


### PR DESCRIPTION
Due to 'vendor/sigs.k8s.io/cluster-api/config/crds/' is a folder, we must use '-k' flag instead of '-f' flag while adding CRDs from cluster-api. This PR intends to update the deployment guide to fix this error.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>